### PR TITLE
Fix GetProfileHandler.cs error

### DIFF
--- a/Servers/PresenceConnectionManager/Handler/CommandHandler/Profile/GetProfile/GetProfileHandler.cs
+++ b/Servers/PresenceConnectionManager/Handler/CommandHandler/Profile/GetProfile/GetProfileHandler.cs
@@ -31,7 +31,7 @@ namespace PresenceConnectionManager.Handler.Profile.GetProfile
                 return;
             }
 
-            if (uint.TryParse(_recv["profileid"], out _profileid))
+            if (!uint.TryParse(_recv["profileid"], out _profileid))
             {
                 _errorCode = GPErrorCode.Parse;
                 return;


### PR DESCRIPTION
Per comment at top of block (\getprofile\\sesskey\19150\profileid\2\id\2\final\) and testing in Crysis Wars. This check will always fail and log the player out, as the string always has ProfileID