### PR TITLE
Opened udp port 27900 for the QueryReport server.

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -59,6 +59,7 @@ services:
     image: gameprogressive/qr
     ports:
     - "27900:27900"
+    - "27900:27900/udp"
     stdin_open: true
     tty: true
 


### PR DESCRIPTION
FlatOut 2 uses udp port 27900 to connect to the QueryReport server.